### PR TITLE
Call useApp in useCanvasSize before early return to prevent inconsistent hook rendering order

### DIFF
--- a/src/hooks/useCanvasSize.ts
+++ b/src/hooks/useCanvasSize.ts
@@ -17,11 +17,12 @@ const defaultCanvasSize = {
 export default function useCanvasSize() {
   const { level: levelIndex } = useData();
   const level = useLevel(levelIndex);
+  const app = useApp();
+
   if (!level) return defaultCanvasSize;
 
   const { cellSize, origoPosition } = level;
 
-  const app = useApp();
   const { width, height } = app.view;
   const scale = window.devicePixelRatio;
   const pixelWidth = width / scale;


### PR DESCRIPTION
An early return in _useCanvasSize_ hook caused inconsistent renders. Oops! 